### PR TITLE
Postgis cql json

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -48,7 +48,7 @@ import urllib.parse
 import uuid
 
 from dateutil.parser import parse as dateparse
-from pygeofilter.parsers.ecql import parse
+from pygeofilter.parsers.ecql import parse as parse_ecql_text
 import pytz
 from shapely.errors import WKTReadingError
 from shapely.wkt import loads as shapely_loads
@@ -1425,7 +1425,7 @@ class API:
         cql = request.params.get('filter')
         if cql is not None:
             try:
-                cql_ast = parse(cql)
+                cql_ast = parse_ecql_text(cql)
             except Exception as err:
                 LOGGER.error(err)
                 msg = f'Bad CQL string : {cql}'

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1835,37 +1835,36 @@ class API:
 
         filter_ = None
         cql_ast = None
-        if filter_lang:
-            try:
-                # Parse bytes data, if applicable
-                data = request.data.decode()
-                LOGGER.debug(data)
-            except UnicodeDecodeError as err:
-                LOGGER.error(err)
-                msg = 'Unicode error in data'
-                return self.get_exception(
-                    400, headers, request.format, 'InvalidParameterValue', msg)
+        try:
+            # Parse bytes data, if applicable
+            data = request.data.decode()
+            LOGGER.debug(data)
+        except UnicodeDecodeError as err:
+            LOGGER.error(err)
+            msg = 'Unicode error in data'
+            return self.get_exception(
+                400, headers, request.format, 'InvalidParameterValue', msg)
 
-            if p.name == 'PostgreSQL':
-                LOGGER.debug('processing PostgreSQL CQL_JSON data')
-                try:
-                    cql_ast = parse_cql_json(data)
-                except Exception as err:
-                    LOGGER.error(err)
-                    msg = f'Bad CQL string : {data}'
-                    return self.get_exception(
-                        400, headers, request.format,
-                        'InvalidParameterValue', msg)
-            else:
-                LOGGER.debug('processing ElasticSearch CQL_JSON data')
-                try:
-                    filter_ = CQLModel.parse_raw(data)
-                except Exception as err:
-                    LOGGER.error(err)
-                    msg = f'Bad CQL string : {data}'
-                    return self.get_exception(
-                        400, headers, request.format,
-                        'InvalidParameterValue', msg)
+        if p.name == 'PostgreSQL':
+            LOGGER.debug('processing PostgreSQL CQL_JSON data')
+            try:
+                cql_ast = parse_cql_json(data)
+            except Exception as err:
+                LOGGER.error(err)
+                msg = f'Bad CQL string : {data}'
+                return self.get_exception(
+                    400, headers, request.format,
+                    'InvalidParameterValue', msg)
+        else:
+            LOGGER.debug('processing ElasticSearch CQL_JSON data')
+            try:
+                filter_ = CQLModel.parse_raw(data)
+            except Exception as err:
+                LOGGER.error(err)
+                msg = f'Bad CQL string : {data}'
+                return self.get_exception(
+                    400, headers, request.format,
+                    'InvalidParameterValue', msg)
 
         try:
             content = p.query(offset=offset, limit=limit,

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -49,6 +49,7 @@ import uuid
 
 from dateutil.parser import parse as dateparse
 from pygeofilter.parsers.ecql import parse as parse_ecql_text
+from pygeofilter.parsers.cql_json import parse as parse_cql_json
 import pytz
 from shapely.errors import WKTReadingError
 from shapely.wkt import loads as shapely_loads
@@ -1840,8 +1841,12 @@ class API:
             LOGGER.debug(data)
             # @TODO validation function
             filter_ = None
+            cql_ast = None
             if val:
-                filter_ = CQLModel.parse_raw(data)
+                if p.name == 'PostgreSQL':
+                    cql_ast = parse_cql_json(data)
+                else:
+                    filter_ = CQLModel.parse_raw(data)
             content = p.query(offset=offset, limit=limit,
                               resulttype=resulttype, bbox=bbox,
                               datetime_=datetime_, properties=properties,
@@ -1849,7 +1854,8 @@ class API:
                               select_properties=select_properties,
                               skip_geometry=skip_geometry,
                               q=q,
-                              filterq=filter_)
+                              filterq=filter_,
+                              cql_ast=cql_ast)
         except (UnicodeDecodeError, AttributeError):
             pass
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -934,6 +934,40 @@ def test_get_collection_items_postgresql_cql_bad_cql(bad_cql):
     assert error_response['description'] == f'Bad CQL string : {bad_cql}'
 
 
+def test_post_collection_items_postgresql_cql():
+    """
+    Test for PostgreSQL CQL - requires local PostgreSQL with appropriate
+    data.  See pygeoapi/provider/postgresql.py for details.
+    """
+    # Arrange
+    # Prepare API configured to use PostgreSQL provider
+    with open(get_test_file_path('pygeoapi-test-config-postgresql.yml')) as fh:
+        config = yaml_load(fh)
+    api_ = API(config)
+    cql = {"and": [{"between": {"value": {"property": "osm_id"},
+                                "lower": 80800000,
+                                "upper": 80900000}},
+                   {"isNull": {"property": "name"}}]}
+    # werkzeug requests use a value of CONTENT_TYPE 'application/json'
+    # to create Content-Type in the Request object. So here we need to
+    # overwrite the default CONTENT_TYPE with the required one.
+    headers = {'CONTENT_TYPE': 'application/query-cql-json'}
+    expected_ids = [80835474, 80835483]
+
+    # Act
+    req = mock_request({
+        'filter-lang': 'cql-json'
+    }, data=cql, **headers)
+    rsp_headers, code, response = api_.post_collection_items(
+        req, 'hot_osm_waterways')
+
+    # Assert
+    assert code == 200
+    features = json.loads(response)
+    ids = [item['id'] for item in features['features']]
+    assert ids == expected_ids
+
+
 def test_get_collection_items_json_ld(config, api_):
     req = mock_request({
         'f': 'jsonld',

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -889,7 +889,7 @@ def test_get_collection_items_postgresql_cql_invalid_filter_language():
 
     # Act
     req = mock_request({
-        'filter-lang': 'cql-json',
+        'filter-lang': 'cql-json',  # Only cql-text is valid for GET
         'filter': cql_query
     })
     rsp_headers, code, response = api_.get_collection_items(
@@ -986,7 +986,7 @@ def test_post_collection_items_postgresql_cql_invalid_filter_language():
 
     # Act
     req = mock_request({
-        'filter-lang': 'cql-text'
+        'filter-lang': 'cql-text'  # Only cql-json is valid for POST
     }, data=cql, **headers)
     rsp_headers, code, response = api_.post_collection_items(
         req, 'hot_osm_waterways')


### PR DESCRIPTION
This PR lets the API handle CQL-JSON queries using POST. The tests, successful query and error cases should pass.

Points to note:
 - the changes should not impact the existing uses of this POST function, but there are no API tests to verify this.
 - the exceptions caught may not be comprehensive
 - the errors codes and messages returned may not be optimal

The API can be tested using a running API with the test Postgres database:

```bash
curl --location \
       --request POST 'http://localhost:5000/collections/hot_osm_waterways/items?f=json&limit=50&filter-lang=cql-json' \
       --header 'Content-Type: application/query-cql-json' \
       --data-raw '{"and": [{"between": {"value": {"property": "osm_id"}, "lower": 80800000, "upper": 80900000}}, {"isNull": {"property": "name"}}]}'
```
 