### PR TITLE
Use filterq only in all CQL calls

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1422,22 +1422,22 @@ class API:
         else:
             skip_geometry = False
 
-        LOGGER.debug('processing cql parameter')
-        cql = request.params.get('filter')
-        if cql is not None:
+        LOGGER.debug('processing filter parameter')
+        cql_text = request.params.get('filter')
+        if cql_text is not None:
             try:
-                cql_ast = parse_ecql_text(cql)
+                filter_ = parse_ecql_text(cql_text)
             except Exception as err:
                 LOGGER.error(err)
-                msg = f'Bad CQL string : {cql}'
+                msg = f'Bad CQL string : {cql_text}'
                 return self.get_exception(
                     400, headers, request.format, 'InvalidParameterValue', msg)
         else:
-            cql_ast = None
+            filter_ = None
 
         LOGGER.debug('Processing filter-lang parameter')
         filter_lang = request.params.get('filter-lang')
-        # Currently only cql-text is handled
+        # Currently only cql-text is handled, but it is optional
         if filter_lang is not None and filter_lang != 'cql-text':
             msg = 'Invalid filter language'
             return self.get_exception(
@@ -1458,7 +1458,7 @@ class API:
         LOGGER.debug('skipGeometry: {}'.format(skip_geometry))
         LOGGER.debug('language: {}'.format(prv_locale))
         LOGGER.debug('q: {}'.format(q))
-        LOGGER.debug('cql_ast: {}'.format(cql_ast))
+        LOGGER.debug('cql_text: {}'.format(cql_text))
         LOGGER.debug('filter-lang: {}'.format(filter_lang))
 
         try:
@@ -1468,7 +1468,7 @@ class API:
                               sortby=sortby,
                               select_properties=select_properties,
                               skip_geometry=skip_geometry,
-                              q=q, language=prv_locale, cql_ast=cql_ast)
+                              q=q, language=prv_locale, filterq=filter_)
         except ProviderConnectionError as err:
             LOGGER.error(err)
             msg = 'connection error (check logs)'
@@ -1834,7 +1834,6 @@ class API:
                 400, headers, request.format, 'MissingParameterValue', msg)
 
         filter_ = None
-        cql_ast = None
         try:
             # Parse bytes data, if applicable
             data = request.data.decode()
@@ -1848,7 +1847,7 @@ class API:
         if p.name == 'PostgreSQL':
             LOGGER.debug('processing PostgreSQL CQL_JSON data')
             try:
-                cql_ast = parse_cql_json(data)
+                filter_ = parse_cql_json(data)
             except Exception as err:
                 LOGGER.error(err)
                 msg = f'Bad CQL string : {data}'
@@ -1874,8 +1873,7 @@ class API:
                               select_properties=select_properties,
                               skip_geometry=skip_geometry,
                               q=q,
-                              filterq=filter_,
-                              cql_ast=cql_ast)
+                              filterq=filter_)
         except ProviderConnectionError as err:
             LOGGER.error(err)
             msg = 'connection error (check logs)'

--- a/tests/test_postgresql_provider.py
+++ b/tests/test_postgresql_provider.py
@@ -234,7 +234,7 @@ def test_query_cql(config, cql, expected_ids):
     ast = parse(cql)
     p = PostgreSQLProvider(config)
 
-    feature_collection = p.query(cql_ast=ast)
+    feature_collection = p.query(filterq=ast)
     assert feature_collection.get('type', None) == 'FeatureCollection'
 
     features = feature_collection.get('features', None)


### PR DESCRIPTION
This PR replaces the effective duplication of `cql_ast` and `filterq` in the queries.

The main get and post collection tests should pass. 