### PR TITLE
WIP: Fix next and prev links in returned JSON

### DIFF
--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1524,9 +1524,9 @@ class API:
                     'type': 'application/geo+json',
                     'rel': 'prev',
                     'title': 'items (prev)',
-                    'href': '{}?offset={}{}'
+                    'href': '{}?f={}&offset={}{}'
                     .format(
-                        uri, prev, serialized_query_params)
+                        uri, F_JSON, prev, serialized_query_params)
                 })
 
         if len(content['features']) == limit:
@@ -1536,9 +1536,9 @@ class API:
                     'type': 'application/geo+json',
                     'rel': 'next',
                     'title': 'items (next)',
-                    'href': '{}?offset={}{}'
+                    'href': '{}?f={}&offset={}{}'
                     .format(
-                        uri, next_, serialized_query_params)
+                        uri, F_JSON, next_, serialized_query_params)
                 })
 
         content['links'].append(

--- a/pygeoapi/api.py
+++ b/pygeoapi/api.py
@@ -1526,7 +1526,7 @@ class API:
                     'title': 'items (prev)',
                     'href': '{}?f={}&offset={}{}'
                     .format(
-                        uri, F_JSON, prev, serialized_query_params)
+                        uri, request.format, prev, serialized_query_params)
                 })
 
         if len(content['features']) == limit:
@@ -1538,7 +1538,7 @@ class API:
                     'title': 'items (next)',
                     'href': '{}?f={}&offset={}{}'
                     .format(
-                        uri, F_JSON, next_, serialized_query_params)
+                        uri, request.format, next_, serialized_query_params)
                 })
 
         content['links'].append(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -670,7 +670,7 @@ def test_get_collection_items(config, api_):
     assert links[1]['rel'] == 'alternate'
     assert '/collections/obs/items?f=html' in links[2]['href']
     assert links[2]['rel'] == 'alternate'
-    assert '/collections/obs/items?offset=2&limit=2' in links[3]['href']
+    assert '/collections/obs/items?f=json&offset=2&limit=2' in links[3]['href']
     assert links[3]['rel'] == 'next'
     assert '/collections/obs' in links[4]['href']
     assert links[4]['rel'] == 'collection'
@@ -697,7 +697,7 @@ def test_get_collection_items(config, api_):
     assert links[1]['rel'] == 'alternate'
     assert '/collections/obs/items?f=html' in links[2]['href']
     assert links[2]['rel'] == 'alternate'
-    assert '/collections/obs/items?offset=0' in links[3]['href']
+    assert '/collections/obs/items?f=json&offset=0' in links[3]['href']
     assert links[3]['rel'] == 'prev'
     assert '/collections/obs' in links[4]['href']
     assert links[4]['rel'] == 'collection'
@@ -723,10 +723,10 @@ def test_get_collection_items(config, api_):
     assert '/collections/obs/items?f=html&limit=1&bbox=-180,90,180,90' in \
         links[2]['href']
     assert links[2]['rel'] == 'alternate'
-    assert '/collections/obs/items?offset=0&limit=1&bbox=-180,90,180,90' \
+    assert '/collections/obs/items?f=json&offset=0&limit=1&bbox=-180,90,180,90' \
         in links[3]['href']
     assert links[3]['rel'] == 'prev'
-    assert '/collections/obs/items?offset=2&limit=1&bbox=-180,90,180,90' \
+    assert '/collections/obs/items?f=json&offset=2&limit=1&bbox=-180,90,180,90' \
         in links[4]['href']
     assert links[4]['rel'] == 'next'
     assert '/collections/obs' in links[5]['href']

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -655,7 +655,7 @@ def test_get_collection_items(config, api_):
     assert len(features['features']) == 1
     assert features['numberMatched'] == 1
 
-    req = mock_request({'limit': 2})
+    req = mock_request({'f': 'json', 'limit': 2})
     rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
 
@@ -682,7 +682,7 @@ def test_get_collection_items(config, api_):
 
     assert code == 400
 
-    req = mock_request({'offset': 2})
+    req = mock_request({'f': 'json', 'offset': 2})
     rsp_headers, code, response = api_.get_collection_items(req, 'obs')
     features = json.loads(response)
 
@@ -703,6 +703,7 @@ def test_get_collection_items(config, api_):
     assert links[4]['rel'] == 'collection'
 
     req = mock_request({
+        'f': 'json',
         'offset': 1,
         'limit': 1,
         'bbox': '-180,90,180,90'

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -724,11 +724,11 @@ def test_get_collection_items(config, api_):
     assert '/collections/obs/items?f=html&limit=1&bbox=-180,90,180,90' in \
         links[2]['href']
     assert links[2]['rel'] == 'alternate'
-    assert '/collections/obs/items?f=json&offset=0&limit=1&bbox=-180,90,180,90' \
-        in links[3]['href']
+    assert ('/collections/obs/items?f=json'
+            '&offset=0&limit=1&bbox=-180,90,180,90') in links[3]['href']
     assert links[3]['rel'] == 'prev'
-    assert '/collections/obs/items?f=json&offset=2&limit=1&bbox=-180,90,180,90' \
-        in links[4]['href']
+    assert ('/collections/obs/items?f=json'
+            '&offset=2&limit=1&bbox=-180,90,180,90') in links[4]['href']
     assert links[4]['rel'] == 'next'
     assert '/collections/obs' in links[5]['href']
     assert links[5]['rel'] == 'collection'


### PR DESCRIPTION
This fixes the next/prev issue outlined below and the modified tests pass. But I'm not 100% I understand what is going on. In the tests the mock requests are made without a format type, but `JSON` is returned. As if `JSON` is the default format. But when using the API if no format is given `HTML` is returned, as if `HTML` is the default. I have not managed to track through the code to see why there is this mismatch.

I have modified the mocks to ask for JSON and the code to use the format in the next/prev links. So It works, but whether it is correct to what they think should be happening is another thing!

I will leave this PR as WIP.

### Background

If you make a call to our current ogcapi asking for JSON data with and offset and limit:

[https://ogcapi.bgs.ac.uk/collections/recentearthquakes/items?f=json&offset=100&limit=100](https://ogcapi.bgs.ac.uk/collections/recentearthquakes/items?f=json&offset=100&limit=100)

And scroll down to the links at the bottom, the `next` and `prev` links don't have a format specified. The same applies for an implied `offset` of zero.
```
        {
            "type": "application/geo+json",
            "rel": "prev",
            "title": "items (prev)",
            "href": "https://ogcapi.bgs.ac.uk/collections/recentearthquakes/items?offset=0&limit=100"
        },
        {
            "type": "application/geo+json",
            "rel": "next",
            "title": "items (next)",
            "href": "https://ogcapi.bgs.ac.uk/collections/recentearthquakes/items?offset=200&limit=100"
        },
```
This means that they return HTML pages not JSON data, as they should.

I am not convinced about the `self` or `alternate` links either since they fail to include the offset:
```
        {
            "type": "application/geo+json",
            "rel": "self",
            "title": "This document as GeoJSON",
            "href": "https://ogcapi.bgs.ac.uk/collections/recentearthquakes/items?f=json&limit=100"
        },
        {
            "rel": "alternate",
            "type": "application/ld+json",
            "title": "This document as RDF (JSON-LD)",
            "href": "https://ogcapi.bgs.ac.uk/collections/recentearthquakes/items?f=jsonld&limit=100"
        },
        {
            "type": "text/html",
            "rel": "alternate",
            "title": "This document as HTML",
            "href": "https://ogcapi.bgs.ac.uk/collections/recentearthquakes/items?f=html&limit=100"
        },
```
The `self` link should make exactly the same call and the two `alternate`s, in my view, should also include the `offset`.

