### PR TITLE
Unquote PostgreSQL column names

### DIFF
--- a/pygeoapi/provider/postgresql.py
+++ b/pygeoapi/provider/postgresql.py
@@ -176,7 +176,7 @@ class PostgreSQLProvider(BaseProvider):
 
         fields = {}
         for column in self.table_model.__table__.columns:
-            fields[column.name] = {'type': str(column.type)}
+            fields[str(column.name)] = {'type': str(column.type)}
 
         fields.pop(self.geom)  # Exclude geometry column
 


### PR DESCRIPTION
This one commit PR unquotes the `sqlalchemy` field names so that they can be picked up in the `openapi` generation.

The branch should deploy successfully and CQL queries should execute. This commit has already been tested effectively on the merged main branch so just needs a sanity check.